### PR TITLE
[BGP] nncp: add ipv4 gateway address to internalapi and storage bridges

### DIFF
--- a/examples/dt/bgp-l3-xl/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/networking/nncp/kustomization.yaml
@@ -1190,3 +1190,45 @@ replacements:
           name: worker-9
         fieldPaths:
           - spec.desiredState.routes
+
+  # internalapi bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.prefix-length
+
+  # storage bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.prefix-length

--- a/examples/dt/bgp-l3-xl/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/bgp-l3-xl/control-plane/networking/nncp/values.yaml
@@ -558,6 +558,7 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
+    gateway: 172.17.0.1
     iface: internalapi
     vlan: 20
     base_iface: enp7s0
@@ -595,6 +596,7 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
+    gateway: 172.18.0.1
     iface: storage
     vlan: 21
     base_iface: enp7s0

--- a/examples/dt/bgp_dt01/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/bgp_dt01/control-plane/networking/nncp/kustomization.yaml
@@ -98,6 +98,11 @@ patches:
           name: octavia
           type: linux-bridge
           state: up
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
   - target:
       kind: NodeNetworkConfigurationPolicy
     patch: |-
@@ -109,6 +114,11 @@ patches:
           name: designate
           type: linux-bridge
           state: up
+          ipv4:
+            address:
+              - ip: _replaced_
+                prefix-length: _replaced_
+            enabled: true
 
 replacements:
   # Node names (workers)
@@ -562,3 +572,153 @@ replacements:
           name: worker-2
         fieldPaths:
           - spec.desiredState.routes
+
+  # internalapi bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.prefix-length
+
+  # storage bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.prefix-length
+
+  # octavia bridge gateway IP and prefix-length
+  # octavia is at index 7 for workers 0-2 (which have 2 BGP ifaces) and index 6 for worker-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.octavia.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.6.ipv4.address.0.prefix-length
+
+  # designate bridge gateway IP and prefix-length
+  # designate is at index 8 for workers 0-2 and index 7 for worker-3
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.ip
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.designate.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-0
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-1
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-2
+        fieldPaths:
+          - spec.desiredState.interfaces.8.ipv4.address.0.prefix-length
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+          name: worker-3
+        fieldPaths:
+          - spec.desiredState.interfaces.7.ipv4.address.0.prefix-length

--- a/examples/dt/bgp_dt01/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/bgp_dt01/control-plane/networking/nncp/values.yaml
@@ -211,6 +211,7 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
+    gateway: 172.17.0.1
     iface: internalapi
     vlan: 20
     base_iface: enp7s0
@@ -249,6 +250,7 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
+    gateway: 172.18.0.1
     iface: storage
     vlan: 21
     base_iface: enp7s0
@@ -281,6 +283,8 @@ data:
         name: subnet1
         vlan: 23
     mtu: 1500
+    prefix-length: 24
+    gateway: 172.23.0.1
     vlan: 23
     base_iface: enp7s0
     net-attach-def: |
@@ -309,6 +313,8 @@ data:
 
   designate:
     # only NAD is used for designate
+    prefix-length: 24
+    gateway: 172.26.0.1
     net-attach-def: |
       {
         "cniVersion": "0.3.1",

--- a/examples/dt/dz-storage/control-plane/networking/nncp/kustomization.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/nncp/kustomization.yaml
@@ -1185,3 +1185,45 @@ replacements:
           name: worker-9
         fieldPaths:
           - spec.desiredState.routes
+
+  # internalapi bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.internalapi.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.0.ipv4.address.0.prefix-length
+
+  # storage bridge gateway IP and prefix-length
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.gateway
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.ip
+
+  - source:
+      kind: ConfigMap
+      name: network-values
+      fieldPath: data.storage.prefix-length
+    targets:
+      - select:
+          kind: NodeNetworkConfigurationPolicy
+        fieldPaths:
+          - spec.desiredState.interfaces.1.ipv4.address.0.prefix-length

--- a/examples/dt/dz-storage/control-plane/networking/nncp/values.yaml
+++ b/examples/dt/dz-storage/control-plane/networking/nncp/values.yaml
@@ -316,6 +316,7 @@ data:
         vlan: 20
     mtu: 1500
     prefix-length: 24
+    gateway: 172.17.0.1
     iface: internalapi
     vlan: 20
     base_iface: enp7s0
@@ -353,6 +354,7 @@ data:
         vlan: 21
     mtu: 1500
     prefix-length: 24
+    gateway: 172.18.0.1
     iface: storage
     vlan: 21
     base_iface: enp7s0

--- a/lib/nncp-l3/ocp_node_template.yaml
+++ b/lib/nncp-l3/ocp_node_template.yaml
@@ -19,11 +19,21 @@ spec:
         state: up
         type: linux-bridge
         mtu: 1500
+        ipv4:
+          address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+          enabled: true
       - description: storage bridge
         name: storage
         state: up
         type: linux-bridge
         mtu: 1500
+        ipv4:
+          address:
+            - ip: _replaced_
+              prefix-length: _replaced_
+          enabled: true
       - description: ctlplane interface
         name: _replaced_
         state: up


### PR DESCRIPTION
## Summary

- Without an explicit `ipv4` address in the NNCP desired state, NMState periodically reconciles the `internalapi` and `storage` bridges and removes the gateway IP that the bridge CNI plugin sets via `isGateway: true` in the NAD.
- Once the gateway IP is removed, the kernel connected route for the network disappears and pod IPs on those bridges become unreachable from compute/networker nodes via BGP, causing `ovn-controller` to become unhealthy. The issue typically manifests after 24+ hours of operation.
- This fix adds the gateway IP (first host IP of each subnet) to the NNCP so NMState preserves it across reconciliation cycles.
- Applies to `lib/nncp-l3` (base template) and all BGP deployment examples that import it (`bgp_dt01`, `bgp-l3-xl`, `dz-storage`).

Fixes: OSPRH-32725

## Test plan

- [ ] Deploy a BGP-based RHOSO environment using the updated NNCP templates
- [ ] Verify `internalapi` and `storage` bridges retain their gateway IPs after NMState reconciliation
- [ ] Verify OVN SB DB pods remain reachable from compute/networker nodes after 24+ hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)